### PR TITLE
Patch EnvironmentVariables plugin to not rewrite config.ini.php

### DIFF
--- a/plugins/EnvironmentVariables/config/config.php
+++ b/plugins/EnvironmentVariables/config/config.php
@@ -7,8 +7,29 @@
  *
  */
 
+class NonWritingConfig extends Piwik\Config
+{
+    public function __construct(Piwik\Config $original)
+    {
+        $this->settings = $original->settings;
+    }
+
+    /**
+     * Dump config
+     *
+     * @return string|null
+     * @throws \Exception
+     */
+    public function dumpConfig()
+    {
+        return false;
+    }
+}
+
 return array(
     'Piwik\Config' => DI\decorate(function ($previous, \Interop\Container\ContainerInterface $c) {
+        $wrapped = new NonWritingConfig($previous);
+
         $settings = $c->get(\Piwik\Application\Kernel\GlobalSettingsProvider::class);
 
         $ini = $settings->getIniFileChain();
@@ -20,13 +41,13 @@ return array(
 
                 $envValue = getenv($settingEnvName);
                 if ($envValue !== false) {
-                    $general = $previous->$category;
+                    $general = $wrapped->$category;
                     $general[$settingName] = $envValue;
-                    $previous->$category = $general;
+                    $wrapped->$category = $general;
                 }
             }
         }
 
-        return $previous;
+        return $wrapped;
     }),
 );


### PR DESCRIPTION
We don't want to rewrite the Matomo config file on each request.  This is not useful for us and in some case the resulting file could be corrupted.

So we patched the config class to rewrite the `dumpConfig` method and do nothing.

PIX intern only: our investigation (in French) is available here https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2253357057/2021-01-18+-+Semaine+3#Mais-pourquoi-donc-Matomo-clignote-il-%3F